### PR TITLE
Remove version lock for docutils from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,6 @@ bump2version = "*"
 # Hotfix for Pipenv's Bug @see https://github.com/pypa/pipenv/issues/4101
 colorama = "*"
 coverage = "*"
-# Hotfix for Pipenv's Bug @see https://github.com/pypa/pipenv/issues/3865
-docutils = "==0.15"
 fixturefilehandler = "*"
 flake8 = "*"
 invoke = "*"


### PR DESCRIPTION
The latest version of docutils doesn't have multiple artifacts.
@see https://github.com/pypa/pipenv/issues/3865